### PR TITLE
Cache Update wrapped in a Transaction

### DIFF
--- a/config-management-core/src/main/scala/com/bloomreach/cms/redis/CacheUpdater.scala
+++ b/config-management-core/src/main/scala/com/bloomreach/cms/redis/CacheUpdater.scala
@@ -88,8 +88,10 @@ class CacheUpdater(val host: String, val port: Int = 6379) extends LazyLogging {
     val jedisPipeline = jedis.pipelined()
     var broken = false
     try {
+      jedisPipeline.multi()
       updateParentsRecursivelyWithPipeline(realm, dbName, documentName, key, JsonMethods.parse(value), jedisPipeline)
       updateChildrenRecursivelyWithPipeline(realm, dbName, documentName, key, JsonMethods.parse(value), jedisPipeline)
+      jedisPipeline.exec()
       jedisPipeline.sync()
     } catch {
       case e: Error => {


### PR DESCRIPTION
All caches updates were batched using Redis Pipelining but
in order to attain atomicity need to wrap all updates in a
Redis Transaction.